### PR TITLE
Make rs-application_php/local_settings_file an input

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -95,6 +95,14 @@ attribute 'rs-application_php/app_root',
     'rs-application_php::tags',
   ]
 
+attribute 'rs-application_php/local_settings_file',
+  :display_name => 'Local Settings File',
+  :description => 'The name of local settings file to be created. The name can also ' +
+    'be path relative to the application code. Default: config/db.php',
+  :default => 'config/db.php',
+  :required => 'recommended',
+  :recipes => ['rs-application_php::default']
+
 attribute 'rs-application_php/bind_network_interface',
   :display_name => 'Application Bind Network Interface',
   :description => "The network interface to use for the bind address of the application server." +


### PR DESCRIPTION
Most customers we see do not have a `config/` directory in their PHP application root.

Since this is the case, this value must be changed otherwise the ServerTemplate will get stranded at boot when trying to symlink this file. This PR exposes this as a recommended input so that it can easily be changed to something else so that this cookbook does not have to be forked and modified.